### PR TITLE
Add InteractiveTxConstructor tests

### DIFF
--- a/lightning/src/events/bump_transaction.rs
+++ b/lightning/src/events/bump_transaction.rs
@@ -37,11 +37,11 @@ use bitcoin::secp256k1;
 use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::secp256k1::ecdsa::Signature;
 
-const EMPTY_SCRIPT_SIG_WEIGHT: u64 = 1 /* empty script_sig */ * WITNESS_SCALE_FACTOR as u64;
+pub(crate) const EMPTY_SCRIPT_SIG_WEIGHT: u64 = 1 /* empty script_sig */ * WITNESS_SCALE_FACTOR as u64;
 
 const BASE_INPUT_SIZE: u64 = 32 /* txid */ + 4 /* vout */ + 4 /* sequence */;
 
-const BASE_INPUT_WEIGHT: u64 = BASE_INPUT_SIZE * WITNESS_SCALE_FACTOR as u64;
+pub(crate) const BASE_INPUT_WEIGHT: u64 = BASE_INPUT_SIZE * WITNESS_SCALE_FACTOR as u64;
 
 /// The parameters required to derive a channel signer via [`SignerProvider`].
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -393,7 +393,7 @@ macro_rules! define_state {
 	($state: ident, $inner: ident, $doc: expr) => {
 		#[doc = $doc]
 		#[derive(Debug)]
-		struct $state($inner);
+		pub(crate) struct $state($inner);
 		impl State for $state {}
 	};
 }
@@ -470,7 +470,7 @@ define_state_transitions!(TX_COMPLETE, LocalTxComplete);
 define_state_transitions!(TX_COMPLETE, RemoteTxComplete);
 
 #[derive(Debug)]
-enum StateMachine {
+pub(crate) enum StateMachine {
 	Indeterminate,
 	LocalChange(LocalChange),
 	RemoteChange(RemoteChange),
@@ -696,6 +696,9 @@ impl InteractiveTxConstructor {
 			}
 		}
 	}
+
+	#[cfg(test)]
+	pub(crate) fn get_state_machine(&self) -> &StateMachine { &self.state_machine }
 }
 
 #[cfg(test)]

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -697,6 +697,7 @@ impl InteractiveTxConstructor {
 		}
 	}
 
+	/// Accessor for internal field (for testability)
 	#[cfg(test)]
 	pub(crate) fn get_state_machine(&self) -> &StateMachine { &self.state_machine }
 }

--- a/lightning/src/ln/interactivetxs.rs
+++ b/lightning/src/ln/interactivetxs.rs
@@ -1,0 +1,916 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use core::ops::Deref;
+use std::collections::HashSet;
+use std::io::sink;
+
+use bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
+use bitcoin::consensus::Encodable;
+use bitcoin::policy::MAX_STANDARD_TX_WEIGHT;
+use bitcoin::{OutPoint, Sequence, Transaction, TxIn, TxOut, PackedLockTime};
+
+use crate::chain::chaininterface::fee_for_weight;
+use crate::events::bump_transaction::{BASE_INPUT_WEIGHT, EMPTY_SCRIPT_SIG_WEIGHT};
+use crate::ln::channel::TOTAL_BITCOIN_SUPPLY_SATOSHIS;
+use crate::ln::{ChannelId, msgs};
+use crate::ln::msgs::SerialId;
+use crate::sign::EntropySource;
+use crate::util::ser::TransactionU16LenLimited;
+
+/// The number of received `tx_add_input` messages during a negotiation at which point the
+/// negotiation MUST be failed.
+const MAX_RECEIVED_TX_ADD_INPUT_COUNT: u16 = 4096;
+
+/// The number of received `tx_add_output` messages during a negotiation at which point the
+/// negotiation MUST be failed.
+const MAX_RECEIVED_TX_ADD_OUTPUT_COUNT: u16 = 4096;
+
+/// The number of inputs or outputs that the state machine can have, before it MUST fail the
+/// negotiation.
+const MAX_INPUTS_OUTPUTS_COUNT: usize = 252;
+
+trait SerialIdExt {
+	fn is_valid_for_initiator(&self) -> bool;
+}
+
+impl SerialIdExt for SerialId {
+	fn is_valid_for_initiator(&self) -> bool {
+		self % 2 == 0
+	}
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AbortReason {
+	InvalidStateTransition,
+	UnexpectedCounterpartyMessage,
+	ReceivedTooManyTxAddInputs,
+	ReceivedTooManyTxAddOutputs,
+	IncorrectInputSequenceValue,
+	IncorrectSerialIdParity,
+	SerialIdUnknown,
+	DuplicateSerialId,
+	PrevTxOutInvalid,
+	ExceededMaximumSatsAllowed,
+	ExceededNumberOfInputsOrOutputs,
+	TransactionTooLarge,
+	BelowDustLimit,
+	InvalidOutputScript,
+	InsufficientFees,
+}
+
+#[derive(Debug)]
+pub struct TxInputWithPrevOutput {
+	input: TxIn,
+	prev_output: TxOut,
+}
+
+#[derive(Debug)]
+struct NegotiationContext {
+	holder_is_initiator: bool,
+	received_tx_add_input_count: u16,
+	received_tx_add_output_count: u16,
+	inputs: Vec<(SerialId, TxInputWithPrevOutput)>,
+	prevtx_outpoints: HashSet<OutPoint>,
+	outputs: Vec<(SerialId, TxOut)>,
+	tx_locktime: PackedLockTime,
+	feerate_sat_per_kw: u32,
+}
+
+impl NegotiationContext {
+	fn is_serial_id_valid_for_counterparty(&self, serial_id: &SerialId) -> bool {
+		// A received `SerialId`'s parity must match the role of the counterparty.
+		self.holder_is_initiator == !serial_id.is_valid_for_initiator()
+	}
+
+	fn counterparty_inputs_contributed(&self) -> impl Iterator<Item=&TxInputWithPrevOutput> + Clone {
+		self.inputs.iter()
+			.filter(move |(serial_id, _)| self.is_serial_id_valid_for_counterparty(serial_id))
+			.map(|(_, input_with_prevout)| input_with_prevout)
+	}
+
+	fn counterparty_outputs_contributed(&self) -> impl Iterator<Item=&TxOut> + Clone{
+		self.outputs.iter()
+			.filter(move |(serial_id, _)| self.is_serial_id_valid_for_counterparty(serial_id))
+			.map(|(_, input_with_prevout)| input_with_prevout)
+	}
+
+	fn remote_tx_add_input(&mut self, msg: &msgs::TxAddInput) -> Result<(), AbortReason> {
+		// The interactive-txs spec calls for us to fail negotiation if the `prevtx` we receive is
+		// invalid. However, we would not need to account for this explicit negotiation failure
+		// mode here since `PeerManager` would already disconnect the peer if the `prevtx` is
+		// invalid; implicitly ending the negotiation.
+
+		if !self.is_serial_id_valid_for_counterparty(&msg.serial_id) {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//     - the `serial_id` has the wrong parity
+			return Err(AbortReason::IncorrectSerialIdParity);
+		}
+
+		if msg.sequence >= 0xFFFFFFFE {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//    - `sequence` is set to `0xFFFFFFFE` or `0xFFFFFFFF`
+			return Err(AbortReason::IncorrectInputSequenceValue);
+		}
+
+		let transaction = msg.prevtx.clone().into_transaction();
+
+		if let Some(tx_out) = transaction.output.get(msg.prevtx_out as usize) {
+			if !tx_out.script_pubkey.is_witness_program() {
+				// The receiving node:
+				//  - MUST fail the negotiation if:
+				//     - the `scriptPubKey` is not a witness program
+				return Err(AbortReason::PrevTxOutInvalid);
+			} else if !self.prevtx_outpoints.insert(OutPoint {
+				txid: transaction.txid(),
+				vout: msg.prevtx_out,
+			}) {
+				// The receiving node:
+				//  - MUST fail the negotiation if:
+				//     - the `prevtx` and `prevtx_vout` are identical to a previously added
+				//       (and not removed) input's
+				return Err(AbortReason::PrevTxOutInvalid);
+			}
+		} else {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//     - `prevtx_vout` is greater or equal to the number of outputs on `prevtx`
+			return Err(AbortReason::PrevTxOutInvalid);
+		}
+
+		self.received_tx_add_input_count += 1;
+		if self.received_tx_add_input_count > MAX_RECEIVED_TX_ADD_INPUT_COUNT {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//     - if has received 4096 `tx_add_input` messages during this negotiation
+			return Err(AbortReason::ReceivedTooManyTxAddInputs);
+		}
+
+		let prev_out = if let Some(prev_out) = msg.prevtx.0.output.get(msg.prevtx_out as usize) {
+			prev_out.clone()
+		} else {
+			return Err(AbortReason::PrevTxOutInvalid);
+		};
+		if self.inputs.iter().any(|(serial_id, _)| *serial_id == msg.serial_id) {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//    - the `serial_id` is already included in the transaction
+			return Err(AbortReason::DuplicateSerialId);
+		}
+		let prev_outpoint = OutPoint {
+			txid: transaction.txid(),
+			vout: msg.prevtx_out,
+		};
+		self.inputs.push((msg.serial_id, TxInputWithPrevOutput {
+			input: TxIn {
+				previous_output: prev_outpoint.clone(),
+				sequence: Sequence(msg.sequence),
+				..Default::default()
+			},
+			prev_output: prev_out,
+		}));
+		self.prevtx_outpoints.insert(prev_outpoint);
+		Ok(())
+	}
+
+	fn remote_tx_remove_input(&mut self, msg: &msgs::TxRemoveInput) -> Result<(), AbortReason> {
+		if !self.is_serial_id_valid_for_counterparty(&msg.serial_id) {
+			return Err(AbortReason::IncorrectSerialIdParity);
+		}
+
+		if let Some(idx) = self.inputs.iter().position(|(serial_id, _)| *serial_id == msg.serial_id) {
+			let (_, input) = self.inputs.remove(idx);
+			self.prevtx_outpoints.remove(&input.input.previous_output);
+			Ok(())
+		} else {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//    - the input or output identified by the `serial_id` was not added by the sender
+			//    - the `serial_id` does not correspond to a currently added input
+			Err(AbortReason::SerialIdUnknown)
+		}
+	}
+
+	fn remote_tx_add_output(&mut self, msg: &msgs::TxAddOutput) -> Result<(), AbortReason> {
+		// The receiving node:
+		//  - MUST fail the negotiation if:
+		//     - the serial_id has the wrong parity
+		if !self.is_serial_id_valid_for_counterparty(&msg.serial_id) {
+			return Err(AbortReason::IncorrectSerialIdParity);
+		}
+
+		self.received_tx_add_output_count += 1;
+		if self.received_tx_add_output_count > MAX_RECEIVED_TX_ADD_OUTPUT_COUNT {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//     - if has received 4096 `tx_add_output` messages during this negotiation
+			return Err(AbortReason::ReceivedTooManyTxAddOutputs);
+		}
+
+		if msg.sats < msg.script.dust_value().to_sat() {
+			// The receiving node:
+			// - MUST fail the negotiation if:
+			//		- the sats amount is less than the dust_limit
+			return Err(AbortReason::BelowDustLimit);
+		}
+		if msg.sats > TOTAL_BITCOIN_SUPPLY_SATOSHIS {
+			// The receiving node:
+			// - MUST fail the negotiation if:
+			//		- the sats amount is greater than 2,100,000,000,000,000 (TOTAL_BITCOIN_SUPPLY_SATOSHIS)
+			return Err(AbortReason::ExceededMaximumSatsAllowed);
+		}
+
+		// The receiving node:
+		//   - MUST accept P2WSH, P2WPKH, P2TR scripts
+		//   - MAY fail the negotiation if script is non-standard
+		if !msg.script.is_v0_p2wpkh() && !msg.script.is_v0_p2wsh() && !msg.script.is_v1_p2tr() {
+			return Err(AbortReason::InvalidOutputScript);
+		}
+
+		if self.outputs.iter().any(|(serial_id, _)| *serial_id == msg.serial_id) {
+			// The receiving node:
+			//  - MUST fail the negotiation if:
+			//    - the `serial_id` is already included in the transaction
+			return Err(AbortReason::DuplicateSerialId);
+		}
+
+		let output = TxOut {
+			value: msg.sats,
+			script_pubkey: msg.script.clone(),
+		};
+		self.outputs.push((msg.serial_id, output));
+		Ok(())
+	}
+
+	fn remote_tx_remove_output(&mut self, msg: &msgs::TxRemoveOutput) -> Result<(), AbortReason> {
+		if !self.is_serial_id_valid_for_counterparty(&msg.serial_id) {
+			return Err(AbortReason::IncorrectSerialIdParity);
+		}
+		if let Some(idx) = self.outputs.iter().position(|(serial_id, _)| *serial_id == msg.serial_id) {
+			self.outputs.remove(idx);
+			Ok(())
+		} else {
+			Err(AbortReason::SerialIdUnknown)
+		}
+	}
+
+	fn local_tx_add_input(&mut self, msg: &msgs::TxAddInput) {
+		let tx = msg.prevtx.clone().into_transaction();
+		let input = TxIn {
+			previous_output: OutPoint {
+				txid: tx.txid(),
+				vout: msg.prevtx_out,
+			},
+			sequence: Sequence(msg.sequence),
+			..Default::default()
+		};
+		debug_assert!((msg.prevtx_out as usize) < tx.output.len());
+		let prev_output = &tx.output[msg.prevtx_out as usize];
+		self.prevtx_outpoints.insert(input.previous_output.clone());
+		self.inputs.push((msg.serial_id, TxInputWithPrevOutput {
+			input,
+			prev_output: prev_output.clone(),
+		}));
+	}
+
+	fn local_tx_add_output(&mut self, msg: &msgs::TxAddOutput) {
+		self.outputs.push((msg.serial_id, TxOut {
+			value: msg.sats,
+			script_pubkey: msg.script.clone(),
+		}));
+	}
+
+	fn local_tx_remove_input(&mut self, msg: &msgs::TxRemoveInput) {
+		if let Some(idx) = self.inputs.iter().position(|(serial_id, _)| *serial_id == msg.serial_id) {
+			self.inputs.remove(idx);
+		}
+	}
+
+	fn local_tx_remove_output(&mut self, msg: &msgs::TxRemoveOutput) {
+		if let Some(idx) = self.outputs.iter().position(|(serial_id, _)| *serial_id == msg.serial_id) {
+			self.outputs.remove(idx);
+		}
+	}
+
+	fn build_transaction(self) -> Result<Transaction, AbortReason> {
+		// The receiving node:
+		// MUST fail the negotiation if:
+
+		// - the peer's total input satoshis is less than their outputs
+		let counterparty_inputs_contributed = self.counterparty_inputs_contributed();
+		let counterparty_inputs_value: u64 = counterparty_inputs_contributed.clone()
+			.map(|input| input.prev_output.value).sum();
+		let counterparty_outputs_contributed = self.counterparty_outputs_contributed();
+		let counterparty_outputs_value: u64 = counterparty_outputs_contributed.clone()
+			.map(|output| output.value).sum();
+		if counterparty_inputs_value < counterparty_outputs_value {
+			return Err(AbortReason::InsufficientFees);
+		}
+
+		// - there are more than 252 inputs
+		// - there are more than 252 outputs
+		if self.inputs.len() > MAX_INPUTS_OUTPUTS_COUNT || self.outputs.len() > MAX_INPUTS_OUTPUTS_COUNT {
+			return Err(AbortReason::ExceededNumberOfInputsOrOutputs);
+		}
+
+		let tx_to_validate = Transaction {
+			version: 2,
+			lock_time: self.tx_locktime,
+			input: self.inputs.iter().map(|(_, input)| input.input.clone()).collect(),
+			output: self.outputs.iter().map(|(_, output)| output.clone()).collect(),
+		};
+		if tx_to_validate.weight() as u32 > MAX_STANDARD_TX_WEIGHT {
+			return Err(AbortReason::TransactionTooLarge);
+		}
+
+		// TODO: How do we enforce their fees cover the witness without knowing its expected length?
+		const INPUT_WEIGHT: u64 = BASE_INPUT_WEIGHT + EMPTY_SCRIPT_SIG_WEIGHT;
+
+		// - the peer's paid feerate does not meet or exceed the agreed feerate (based on the minimum fee).
+		let counterparty_output_weight_contributed: u64 = counterparty_outputs_contributed.clone().map(|output|
+			(8 /* value */ + output.script_pubkey.consensus_encode(&mut sink()).unwrap() as u64) *
+				WITNESS_SCALE_FACTOR as u64
+		).sum();
+		let counterparty_weight_contributed = counterparty_output_weight_contributed +
+			counterparty_inputs_contributed.clone().count() as u64 * INPUT_WEIGHT;
+		let counterparty_fees_contributed =
+			counterparty_inputs_value.saturating_sub(counterparty_outputs_value);
+		let mut required_counterparty_contribution_fee = fee_for_weight(self.feerate_sat_per_kw, counterparty_weight_contributed);
+		if !self.holder_is_initiator {
+		    // if is the non-initiator:
+		    // 	- the initiator's fees do not cover the common fields (version, segwit marker + flag,
+		    // 		input count, output count, locktime)
+		    let tx_common_fields_weight =
+		        (4 /* version */ + 4 /* locktime */ + 1 /* input count */ + 1 /* output count */) *
+		            WITNESS_SCALE_FACTOR as u64 + 2 /* segwit marker + flag */;
+		    let tx_common_fields_fee = fee_for_weight(self.feerate_sat_per_kw, tx_common_fields_weight);
+		    required_counterparty_contribution_fee += tx_common_fields_fee;
+		}
+		if counterparty_fees_contributed < required_counterparty_contribution_fee {
+		    return Err(AbortReason::InsufficientFees);
+		}
+
+		Ok(tx_to_validate)
+	}
+}
+
+// Channel states that can receive `(send|receive)_tx_(add|remove)_(input|output)`
+trait State {}
+
+trait LocalState: State {
+	fn into_negotiation_context(self) -> NegotiationContext;
+}
+
+trait RemoteState: State {
+	fn into_negotiation_context(self) -> NegotiationContext;
+}
+
+macro_rules! define_state {
+	(LOCAL_STATE, $state: ident, $doc: expr) => {
+		define_state!($state, NegotiationContext, $doc);
+		impl LocalState for $state {
+			fn into_negotiation_context(self) -> NegotiationContext {
+				self.0
+			}
+		}
+	};
+	(REMOTE_STATE, $state: ident, $doc: expr) => {
+		define_state!($state, NegotiationContext, $doc);
+		impl RemoteState for $state {
+			fn into_negotiation_context(self) -> NegotiationContext {
+				self.0
+			}
+		}
+	};
+	($state: ident, $inner: ident, $doc: expr) => {
+		#[doc = $doc]
+		#[derive(Debug)]
+		struct $state($inner);
+		impl State for $state {}
+	};
+}
+
+define_state!(LOCAL_STATE, LocalChange, "We have sent a message to the counterparty that has affected our negotiation state.");
+define_state!(LOCAL_STATE, LocalTxComplete, "We have sent a `tx_complete` message and are awaiting the counterparty's.");
+define_state!(REMOTE_STATE, RemoteChange, "We have received a message from the counterparty that has affected our negotiation state.");
+define_state!(REMOTE_STATE, RemoteTxComplete, "We have received a `tx_complete` message and the counterparty is awaiting ours.");
+define_state!(NegotiationComplete, Transaction, "We have exchanged consecutive `tx_complete` messages with the counterparty and the transaction negotiation is complete.");
+define_state!(NegotiationAborted, AbortReason, "The negotiation has failed and cannot be continued.");
+
+type StateTransitionResult<S> = Result<S, AbortReason>;
+
+trait StateTransition<NewState: State, TransitionData> {
+	fn transition(self, data: TransitionData) -> StateTransitionResult<NewState>;
+}
+
+macro_rules! define_state_transitions {
+	(LOCAL_STATE, [$(DATA $data: ty, TRANSITION $transition: ident),+]) => {
+		$(
+			impl<S: LocalState> StateTransition<RemoteChange, $data> for S {
+				fn transition(self, data: $data) -> StateTransitionResult<RemoteChange> {
+					let mut context = self.into_negotiation_context();
+					let _ = context.$transition(data)?;
+					Ok(RemoteChange(context))
+				}
+			}
+		 )*
+	};
+	(REMOTE_STATE, [$(DATA $data: ty, TRANSITION $transition: ident),+]) => {
+		$(
+			impl<S: RemoteState> StateTransition<LocalChange, $data> for S {
+				fn transition(self, data: $data) -> StateTransitionResult<LocalChange> {
+					let mut context = self.into_negotiation_context();
+					let _ = context.$transition(data);
+					Ok(LocalChange(context))
+				}
+			}
+		 )*
+	};
+	(TX_COMPLETE_AS_ACK, $from_state: ident, $to_state: ident) => {
+		impl StateTransition<$to_state, &msgs::TxComplete> for $from_state {
+			fn transition(self, _data: &msgs::TxComplete) -> StateTransitionResult<$to_state> {
+				Ok($to_state(self.into_negotiation_context()))
+			}
+		}
+	};
+	(TX_COMPLETE, $from_state: ident) => {
+		impl StateTransition<NegotiationComplete, &msgs::TxComplete> for $from_state {
+			fn transition(self, _data: &msgs::TxComplete) -> StateTransitionResult<NegotiationComplete> {
+				let context = self.into_negotiation_context();
+				let tx = context.build_transaction()?;
+				Ok(NegotiationComplete(tx))
+			}
+		}
+	};
+}
+
+define_state_transitions!(LOCAL_STATE, [
+	DATA &msgs::TxAddInput, TRANSITION remote_tx_add_input,
+	DATA &msgs::TxRemoveInput, TRANSITION remote_tx_remove_input,
+	DATA &msgs::TxAddOutput, TRANSITION remote_tx_add_output,
+	DATA &msgs::TxRemoveOutput, TRANSITION remote_tx_remove_output
+]);
+define_state_transitions!(REMOTE_STATE, [
+	DATA &msgs::TxAddInput, TRANSITION local_tx_add_input,
+	DATA &msgs::TxRemoveInput, TRANSITION local_tx_remove_input,
+	DATA &msgs::TxAddOutput, TRANSITION local_tx_add_output,
+	DATA &msgs::TxRemoveOutput, TRANSITION local_tx_remove_output
+]);
+define_state_transitions!(TX_COMPLETE_AS_ACK, LocalChange, RemoteTxComplete);
+define_state_transitions!(TX_COMPLETE_AS_ACK, RemoteChange, LocalTxComplete);
+define_state_transitions!(TX_COMPLETE, LocalTxComplete);
+define_state_transitions!(TX_COMPLETE, RemoteTxComplete);
+
+#[derive(Debug)]
+enum StateMachine {
+	Indeterminate,
+	LocalChange(LocalChange),
+	RemoteChange(RemoteChange),
+	LocalTxComplete(LocalTxComplete),
+	RemoteTxComplete(RemoteTxComplete),
+	NegotiationComplete(NegotiationComplete),
+	NegotiationAborted(NegotiationAborted),
+}
+
+impl Default for StateMachine {
+	fn default() -> Self {
+		Self::Indeterminate
+	}
+}
+
+macro_rules! define_state_machine_transitions {
+	($transition: ident, $msg: ty, [$(FROM $from_state: ident, TO $to_state: ident),+]) => {
+		fn $transition(self, msg: $msg) -> StateMachine {
+			match self {
+				$(
+					Self::$from_state(s) => match s.transition(msg) {
+						Ok(new_state) => StateMachine::$to_state(new_state),
+						Err(abort_reason) => StateMachine::NegotiationAborted(NegotiationAborted(abort_reason)),
+					}
+				 )*
+				_ => StateMachine::NegotiationAborted(NegotiationAborted(AbortReason::UnexpectedCounterpartyMessage)),
+			}
+		}
+	};
+	(LOCAL_OR_REMOTE_CHANGE, $to_local_transition: ident, $to_remote_transition: ident, $msg: ty) => {
+		define_state_machine_transitions!($to_local_transition, $msg, [
+			FROM RemoteChange, TO LocalChange,
+			FROM RemoteTxComplete, TO LocalChange
+		]);
+		define_state_machine_transitions!($to_remote_transition, $msg, [
+			FROM LocalChange, TO RemoteChange,
+			FROM LocalTxComplete, TO RemoteChange
+		]);
+	};
+}
+
+impl StateMachine {
+	fn new(feerate_sat_per_kw: u32, is_initiator: bool, tx_locktime: PackedLockTime) -> Self {
+		let context = NegotiationContext {
+			tx_locktime,
+			holder_is_initiator: is_initiator,
+			received_tx_add_input_count: 0,
+			received_tx_add_output_count: 0,
+			inputs: vec![],
+			prevtx_outpoints: HashSet::new(),
+			outputs: vec![],
+			feerate_sat_per_kw,
+		};
+		if is_initiator {
+			Self::RemoteChange(RemoteChange(context))
+		} else {
+			Self::LocalChange(LocalChange(context))
+		}
+	}
+
+	define_state_machine_transitions!(
+		LOCAL_OR_REMOTE_CHANGE, local_tx_add_input, remote_tx_add_input, &msgs::TxAddInput
+	);
+	define_state_machine_transitions!(
+		LOCAL_OR_REMOTE_CHANGE, local_tx_add_output, remote_tx_add_output, &msgs::TxAddOutput
+	);
+	define_state_machine_transitions!(
+		LOCAL_OR_REMOTE_CHANGE, local_tx_remove_input, remote_tx_remove_input, &msgs::TxRemoveInput
+	);
+	define_state_machine_transitions!(
+		LOCAL_OR_REMOTE_CHANGE, local_tx_remove_output, remote_tx_remove_output, &msgs::TxRemoveOutput
+	);
+	define_state_machine_transitions!(local_tx_complete, &msgs::TxComplete, [
+		FROM RemoteChange, TO LocalTxComplete,
+		FROM RemoteTxComplete, TO NegotiationComplete
+	]);
+	define_state_machine_transitions!(remote_tx_complete, &msgs::TxComplete, [
+		FROM LocalChange, TO RemoteTxComplete,
+		FROM LocalTxComplete, TO NegotiationComplete
+	]);
+}
+
+pub struct InteractiveTxConstructor {
+	state_machine: StateMachine,
+	channel_id: ChannelId,
+	inputs_to_contribute: Vec<(SerialId, TxIn, Transaction)>,
+	outputs_to_contribute: Vec<(SerialId, TxOut)>,
+}
+
+pub enum InteractiveTxMessageSend {
+	TxAddInput(msgs::TxAddInput),
+	TxAddOutput(msgs::TxAddOutput),
+	TxComplete(msgs::TxComplete),
+}
+
+macro_rules! do_state_transition {
+	($self: ident, $transition: ident, $msg: expr) => {{
+		let state_machine = core::mem::take(&mut $self.state_machine);
+		$self.state_machine = state_machine.$transition($msg);
+		match &$self.state_machine {
+			StateMachine::NegotiationAborted(state) => Err(state.0.clone()),
+			_ => Ok(()),
+		}
+	}};
+}
+
+fn generate_local_serial_id<ES: Deref>(entropy_source: &ES, is_initiator: bool) -> SerialId where ES::Target: EntropySource {
+	let rand_bytes = entropy_source.get_secure_random_bytes();
+	let mut serial_id_bytes = [0u8; 8];
+	serial_id_bytes.copy_from_slice(&rand_bytes[..8]);
+	let mut serial_id = u64::from_be_bytes(serial_id_bytes);
+	if serial_id.is_valid_for_initiator() != is_initiator {
+		serial_id ^= 1;
+	}
+	serial_id
+}
+
+// TODO: Check spec to see if it dictates what needs to happen if a node receives an unexpected message.
+impl InteractiveTxConstructor {
+	pub fn new<ES: Deref>(
+		entropy_source: &ES, channel_id: ChannelId, feerate_sat_per_kw: u32, is_initiator: bool,
+		tx_locktime: PackedLockTime, inputs_to_contribute: Vec<(TxIn, Transaction)>,
+		outputs_to_contribute: Vec<TxOut>,
+	) -> (Self, Option<InteractiveTxMessageSend>)
+	where
+		ES::Target: EntropySource,
+	{
+		let state_machine = StateMachine::new(feerate_sat_per_kw, is_initiator, tx_locktime);
+		let inputs_to_contribute = inputs_to_contribute.into_iter().map(|(input, tx)| {
+			let serial_id = generate_local_serial_id(entropy_source, is_initiator);
+			(serial_id, input, tx)
+		}).collect();
+		let outputs_to_contribute = outputs_to_contribute.into_iter().map(|output| {
+			let serial_id = generate_local_serial_id(entropy_source, is_initiator);
+			(serial_id, output)
+		}).collect();
+		let mut constructor = Self {
+			state_machine,
+			channel_id,
+			inputs_to_contribute,
+			outputs_to_contribute,
+		};
+		let message_send = if is_initiator {
+			match constructor.do_local_state_transition() {
+				Ok(msg_send) => Some(msg_send),
+				Err(_) => {
+					debug_assert!(false, "We should always be able to start our state machine successfully");
+					None
+				}
+			}
+		} else {
+			None
+		};
+		(constructor, message_send)
+	}
+
+	fn do_local_state_transition(&mut self) -> Result<InteractiveTxMessageSend, AbortReason> {
+		if let Some((serial_id, input, prev_tx)) = self.inputs_to_contribute.pop() {
+			let msg = msgs::TxAddInput {
+				channel_id: self.channel_id,
+				serial_id,
+				prevtx: TransactionU16LenLimited(prev_tx),
+				prevtx_out: input.previous_output.vout,
+				sequence: input.sequence.to_consensus_u32(),
+			};
+			let _ = do_state_transition!(self, local_tx_add_input, &msg)?;
+			Ok(InteractiveTxMessageSend::TxAddInput(msg))
+		} else if let Some((serial_id, output)) = self.outputs_to_contribute.pop() {
+			let msg = msgs::TxAddOutput {
+				channel_id: self.channel_id,
+				serial_id,
+				sats: output.value,
+				script: output.script_pubkey,
+			};
+			let _ = do_state_transition!(self, local_tx_add_output, &msg)?;
+			Ok(InteractiveTxMessageSend::TxAddOutput(msg))
+		} else {
+			let msg = msgs::TxComplete { channel_id: self.channel_id };
+			let _ = do_state_transition!(self, local_tx_complete, &msg)?;
+			Ok(InteractiveTxMessageSend::TxComplete(msg))
+		}
+	}
+
+	pub fn handle_tx_add_input(&mut self, msg: &msgs::TxAddInput) -> Result<InteractiveTxMessageSend, AbortReason> {
+		let _ = do_state_transition!(self, remote_tx_add_input, msg)?;
+		self.do_local_state_transition()
+	}
+
+	pub fn handle_tx_remove_input(&mut self, msg: &msgs::TxRemoveInput) -> Result<InteractiveTxMessageSend, AbortReason> {
+		let _ = do_state_transition!(self, remote_tx_remove_input, msg)?;
+		self.do_local_state_transition()
+	}
+
+	pub fn handle_tx_add_output(&mut self, msg: &msgs::TxAddOutput) -> Result<InteractiveTxMessageSend, AbortReason> {
+		let _ = do_state_transition!(self, remote_tx_add_output, msg)?;
+		self.do_local_state_transition()
+	}
+
+	pub fn handle_tx_remove_output(&mut self, msg: &msgs::TxRemoveOutput) -> Result<InteractiveTxMessageSend, AbortReason> {
+		let _ = do_state_transition!(self, remote_tx_remove_output, msg)?;
+		self.do_local_state_transition()
+	}
+
+	pub fn handle_tx_complete(&mut self, msg: &msgs::TxComplete) -> Result<(Option<InteractiveTxMessageSend>, Option<Transaction>), AbortReason> {
+		let _ = do_state_transition!(self, remote_tx_complete, msg)?;
+		match &self.state_machine {
+			StateMachine::RemoteTxComplete(_) => {
+				let msg_send = self.do_local_state_transition()?;
+				let negotiated_tx = match &self.state_machine {
+					StateMachine::NegotiationComplete(s) => Some(s.0.clone()),
+					StateMachine::LocalChange(_) => None, // We either had an input or output to contribute.
+					_ => {
+						debug_assert!(false, "We cannot transition to any other states after receiving `tx_complete` and responding");
+						return Err(AbortReason::InvalidStateTransition);
+					}
+				};
+				Ok((Some(msg_send), negotiated_tx))
+			}
+			StateMachine::NegotiationComplete(s) => Ok((None, Some(s.0.clone()))),
+			_ => {
+				debug_assert!(false, "We cannot transition to any other states after receiving `tx_complete`");
+				Err(AbortReason::InvalidStateTransition)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use core::default::Default;
+	use crate::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+	use crate::ln::interactivetxs::{AbortReason, InteractiveTxConstructor, InteractiveTxMessageSend};
+	use bitcoin::{OutPoint, PackedLockTime, Sequence, Transaction, TxIn, TxOut};
+	use bitcoin::blockdata::opcodes;
+	use bitcoin::blockdata::script::Builder;
+	use crate::ln::ChannelId;
+	use crate::sign::EntropySource;
+	use crate::util::atomic_counter::AtomicCounter;
+
+	struct TestEntropySource(AtomicCounter);
+	impl EntropySource for TestEntropySource {
+		fn get_secure_random_bytes(&self) -> [u8; 32] {
+			let bytes = self.0.get_increment().to_be_bytes();
+			let mut res = [0u8; 32];
+			res[0..8].copy_from_slice(&bytes);
+			res
+		}
+	}
+	struct TestSession {
+		inputs_a: Vec<(TxIn, Transaction)>,
+		outputs_a: Vec<TxOut>,
+		inputs_b: Vec<(TxIn, Transaction)>,
+		outputs_b: Vec<TxOut>,
+		expect_error: Option<AbortReason>,
+	}
+
+	fn do_test_interactive_tx_constructor(session: TestSession) {
+		let entropy_source = TestEntropySource(AtomicCounter::new());
+		let channel_id = ChannelId(entropy_source.get_secure_random_bytes());
+		let tx_locktime = PackedLockTime(1337);
+
+		let (mut constructor_a, first_message_a) = InteractiveTxConstructor::new(
+			&&entropy_source, channel_id, FEERATE_FLOOR_SATS_PER_KW * 10, true, tx_locktime, session.inputs_a.clone(), session.outputs_a.clone()
+		);
+		let (mut constructor_b, first_message_b) = InteractiveTxConstructor::new(
+			&&entropy_source, channel_id, FEERATE_FLOOR_SATS_PER_KW * 10, false, tx_locktime, session.inputs_b.clone(), session.outputs_b.clone()
+		);
+
+		let handle_message_send = |msg: InteractiveTxMessageSend, for_constructor: &mut InteractiveTxConstructor| {
+			match msg {
+				InteractiveTxMessageSend::TxAddInput(msg) => {
+					for_constructor.handle_tx_add_input(&msg).map(|msg_send| (Some(msg_send), None))
+				},
+				InteractiveTxMessageSend::TxAddOutput(msg) => {
+					for_constructor.handle_tx_add_output(&msg).map(|msg_send| (Some(msg_send), None))
+				},
+				InteractiveTxMessageSend::TxComplete(msg) => {
+					for_constructor.handle_tx_complete(&msg)
+				},
+			}
+		};
+
+		assert!(first_message_b.is_none());
+		let mut message_send_a = first_message_a;
+		let mut message_send_b = None;
+		let mut final_tx_a = None;
+		let mut final_tx_b = None;
+		while final_tx_a.is_none() || final_tx_b.is_none()  {
+			if let Some(message_send_a) = message_send_a.take() {
+				match handle_message_send(message_send_a, &mut constructor_b) {
+					Ok((msg_send, final_tx)) => {
+						message_send_b = msg_send;
+						final_tx_b = final_tx;
+					}
+					Err(abort_reason) => {
+						assert_eq!(Some(abort_reason), session.expect_error);
+						return;
+					},
+				}
+			}
+			if let Some(message_send_b) = message_send_b.take() {
+				match handle_message_send(message_send_b, &mut constructor_a) {
+					Ok((msg_send, final_tx)) => {
+						message_send_a = msg_send;
+						final_tx_a = final_tx;
+					}
+					Err(abort_reason) => {
+						assert_eq!(Some(abort_reason), session.expect_error);
+						return;
+					},
+				}
+			}
+		}
+		assert!(message_send_a.is_none());
+		assert!(message_send_b.is_none());
+		assert_eq!(final_tx_a, final_tx_b);
+		assert!(session.expect_error.is_none());
+	}
+
+	fn generate_tx(values: &[u64]) -> Transaction {
+		Transaction {
+			version: 2,
+			lock_time: PackedLockTime(1337),
+			input: vec![TxIn { ..Default::default() }],
+			output: values.iter().map(|value| TxOut {
+				value: *value,
+				script_pubkey: Builder::new().push_opcode(opcodes::OP_TRUE).into_script().to_v0_p2wsh(),
+			}).collect(),
+		}
+	}
+
+	fn generate_inputs(values: &[u64]) -> Vec<(TxIn, Transaction)> {
+		let tx = generate_tx(values);
+		let txid = tx.txid();
+		tx.output.iter().enumerate().map(|(idx, _)| {
+			let input = TxIn {
+				previous_output: OutPoint {
+					txid: txid,
+					vout: idx as u32,
+				},
+				script_sig: Default::default(),
+				sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+				witness: Default::default(),
+			};
+			(input, tx.clone())
+		}).collect()
+	}
+
+	fn generate_output(value: u64) -> TxOut {
+		TxOut { value, script_pubkey: Builder::new().push_opcode(opcodes::OP_TRUE).into_script().to_v0_p2wsh() }
+	}
+
+	#[test]
+	fn test_interactive_tx_constructor() {
+		// No contributions.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: vec![],
+			outputs_a: vec![],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::InsufficientFees),
+		});
+		// Single contribution, no initiator inputs.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: vec![],
+			outputs_a: vec![generate_output(1_000_000)],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::InsufficientFees),
+		});
+		// Single contribution, no initiator outputs.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: generate_inputs(&[1_000_000]),
+			outputs_a: vec![],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: None,
+		});
+		// Single contribution, insufficient fees.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: generate_inputs(&[1_000_000]),
+			outputs_a: vec![generate_output(1_000_000)],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::InsufficientFees),
+		});
+		// Initiator contributes sufficient fees, but non-initiator does not.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: generate_inputs(&[1_000_000]),
+			outputs_a: vec![],
+			inputs_b: generate_inputs(&[100_000]),
+			outputs_b: vec![generate_output(100_000)],
+			expect_error: Some(AbortReason::InsufficientFees),
+		});
+		// Multi-input-output contributions from both sides.
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: generate_inputs(&[1_000_000, 1_000_000]),
+			outputs_a: vec![generate_output(1_000_000), generate_output(200_000)],
+			inputs_b: generate_inputs(&[1_000_000, 500_000]),
+			outputs_b: vec![generate_output(1_000_000), generate_output(400_000)],
+			expect_error: None,
+		});
+		// Invalid input sequence from initiator.
+		let tx = generate_tx(&[1_000_000]);
+		let invalid_sequence_input = TxIn {
+			previous_output: OutPoint { txid: tx.txid(), vout: 0 },
+			..Default::default()
+		};
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: vec![(invalid_sequence_input, tx.clone())],
+			outputs_a: vec![generate_output(1_000_000)],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::IncorrectInputSequenceValue),
+		});
+		// Duplicate prevout from initiator.
+		let duplicate_input = TxIn {
+			previous_output: OutPoint { txid: tx.txid(), vout: 0 },
+			sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+			..Default::default()
+		};
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: vec![(duplicate_input.clone(), tx.clone()), (duplicate_input, tx.clone())],
+			outputs_a: vec![generate_output(1_000_000)],
+			inputs_b: vec![],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::PrevTxOutInvalid),
+		});
+		// Non-initiator uses same prevout as initiator.
+		let duplicate_input = TxIn {
+			previous_output: OutPoint { txid: tx.txid(), vout: 0 },
+			sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+			..Default::default()
+		};
+		do_test_interactive_tx_constructor(TestSession {
+			inputs_a: vec![(duplicate_input.clone(), tx.clone())],
+			outputs_a: vec![generate_output(1_000_000)],
+			inputs_b: vec![(duplicate_input.clone(), tx.clone())],
+			outputs_b: vec![],
+			expect_error: Some(AbortReason::PrevTxOutInvalid),
+		});
+	}
+}

--- a/lightning/src/ln/interactivetxs_tests.rs
+++ b/lightning/src/ln/interactivetxs_tests.rs
@@ -171,11 +171,6 @@ mod tests {
 		}
 	}
 
-	#[test]
-	fn test_negotiating_context_is_serial_id_valid() {
-
-	}
-
 	// Use shortened names here, InvHM for InvokeHandleMethod
 	#[derive(Debug)]
 	enum InvHM {
@@ -184,14 +179,11 @@ mod tests {
 		Comp(ChannelId),   // Complete
 	}
 
-	// TODO return proper error
 	impl InvHM {
-		//fn do_invoke<ES: Deref>(
 		fn do_invoke(
 			&self,
 			interact_tx: &mut InteractiveTxConstructor,
 		) -> Result<(Option<InteractiveTxMessageSend>, Option<Transaction>), AbortReason>
-		// where ES::Target: EntropySource,
 		{
 			match self {
 				InvHM::AddI(txai) => {
@@ -353,7 +345,7 @@ mod tests {
 		expected_state: ExInvRes,
 	}
 
-	// Test helper: create an InteractiveTxConstructor, and perform a number of steps, and check results after each.
+	/// Test helper: create an InteractiveTxConstructor, and perform a number of steps, and check results after each.
 	fn run_interactive_tx(
 		channel_id: ChannelId,
 		is_initiator: bool,
@@ -835,86 +827,3 @@ mod tests {
 	}
 }
 
-// #[cfg(test)]
-// mod tests {
-// 	use core::str::FromStr;
-// 	use crate::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
-// use crate::ln::interactivetxs::ChannelMode::{Negotiating, NegotiationAborted};
-// 	use crate::ln::interactivetxs::{AbortReason, ChannelMode, InteractiveTxConstructor, InteractiveTxStateMachine};
-// 	use crate::ln::msgs::TransactionU16LenLimited;
-// 	use bitcoin::consensus::encode;
-// 	use bitcoin::{Address, PackedLockTime, Script, Sequence, Transaction, Txid, TxIn, TxOut, Witness};
-// 	use bitcoin::hashes::hex::FromHex;
-// 	use crate::chain::transaction::OutPoint;
-// 	use crate::ln::interactivetxs::AbortReason::IncorrectSerialIdParity;
-// 	use crate::ln::msgs::TxAddInput;
-//
-// 	#[test]
-// 	fn test_invalid_counterparty_serial_id_should_abort_negotiation() {
-// 		let tx: Transaction = encode::deserialize(&hex::decode("020000000001010e0ade\
-// 			f48412e4361325ac1c6e36411299ab09d4f083b9d8ddb55fbc06e1b0c00000000000feffffff0220a107000\
-// 			0000000220020f81d95e040bd0a493e38bae27bff52fe2bb58b93b293eb579c01c31b05c5af1dc072cfee54\
-// 			a3000016001434b1d6211af5551905dc2642d05f5b04d25a8fe80247304402207f570e3f0de50546aad25a8\
-// 			72e3df059d277e776dda4269fa0d2cc8c2ee6ec9a022054e7fae5ca94d47534c86705857c24ceea3ad51c69\
-// 			dd6051c5850304880fc43a012103cb11a1bacc223d98d91f1946c6752e358a5eb1a1c983b3e6fb15378f453\
-// 			b76bd00000000").unwrap()[..]).unwrap();
-// 		let mut constructor = InteractiveTxConstructor::new([0; 32], FEERATE_FLOOR_SATS_PER_KW, true, true, tx, false);
-// 		constructor.receive_tx_add_input(2, &get_sample_tx_add_input(), false);
-// 		assert!(matches!(constructor.mode, ChannelMode::NegotiationAborted { .. }))
-// 	}
-//
-// 	impl DummyChannel {
-// 		fn new() -> Self {
-// 			let tx: Transaction = encode::deserialize(&hex::decode("020000000001010e0ade\
-// 			f48412e4361325ac1c6e36411299ab09d4f083b9d8ddb55fbc06e1b0c00000000000feffffff0220a107000\
-// 			0000000220020f81d95e040bd0a493e38bae27bff52fe2bb58b93b293eb579c01c31b05c5af1dc072cfee54\
-// 			a3000016001434b1d6211af5551905dc2642d05f5b04d25a8fe80247304402207f570e3f0de50546aad25a8\
-// 			72e3df059d277e776dda4269fa0d2cc8c2ee6ec9a022054e7fae5ca94d47534c86705857c24ceea3ad51c69\
-// 			dd6051c5850304880fc43a012103cb11a1bacc223d98d91f1946c6752e358a5eb1a1c983b3e6fb15378f453\
-// 			b76bd00000000").unwrap()[..]).unwrap();
-// 			Self {
-// 				tx_constructor: InteractiveTxConstructor::new([0; 32], FEERATE_FLOOR_SATS_PER_KW, true, true, tx, false)
-// 			}
-// 		}
-//
-// 		fn handle_add_tx_input(&mut self) {
-// 			self.tx_constructor.receive_tx_add_input(1234, &get_sample_tx_add_input(), true)
-// 		}
-// 	}
-//
-// 	// Fixtures
-// 	fn get_sample_tx_add_input() -> TxAddInput {
-// 		let prevtx = TransactionU16LenLimited::new(
-// 			Transaction {
-// 				version: 2,
-// 				lock_time: PackedLockTime(0),
-// 				input: vec![TxIn {
-// 					previous_output: OutPoint { txid: Txid::from_hex("305bab643ee297b8b6b76b320792c8223d55082122cb606bf89382146ced9c77").unwrap(), index: 2 }.into_bitcoin_outpoint(),
-// 					script_sig: Script::new(),
-// 					sequence: Sequence(0xfffffffd),
-// 					witness: Witness::from_vec(vec![
-// 						hex::decode("304402206af85b7dd67450ad12c979302fac49dfacbc6a8620f49c5da2b5721cf9565ca502207002b32fed9ce1bf095f57aeb10c36928ac60b12e723d97d2964a54640ceefa701").unwrap(),
-// 						hex::decode("0301ab7dc16488303549bfcdd80f6ae5ee4c20bf97ab5410bbd6b1bfa85dcd6944").unwrap()]),
-// 				}],
-// 				output: vec![
-// 					TxOut {
-// 						value: 12704566,
-// 						script_pubkey: Address::from_str("bc1qzlffunw52jav8vwdu5x3jfk6sr8u22rmq3xzw2").unwrap().script_pubkey(),
-// 					},
-// 					TxOut {
-// 						value: 245148,
-// 						script_pubkey: Address::from_str("bc1qxmk834g5marzm227dgqvynd23y2nvt2ztwcw2z").unwrap().script_pubkey(),
-// 					},
-// 				],
-// 			}
-// 		).unwrap();
-//
-// 		return TxAddInput {
-// 			channel_id: [2; 32],
-// 			serial_id: 4886718345,
-// 			prevtx,
-// 			prevtx_out: 305419896,
-// 			sequence: 305419896,
-// 		};
-// 	}
-// }

--- a/lightning/src/ln/interactivetxs_tests.rs
+++ b/lightning/src/ln/interactivetxs_tests.rs
@@ -1,0 +1,920 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+#[cfg(test)]
+mod tests {
+	use crate::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+	use crate::chain::transaction::OutPoint;
+	use crate::ln::interactivetxs::{InteractiveTxConstructor, InteractiveTxMessageSend, StateMachine, AbortReason};
+	use crate::ln::msgs::{TxAddInput, TxAddOutput, TxComplete};
+	use crate::ln::ChannelId;
+	use crate::sign::EntropySource;
+	use crate::util::ser::TransactionU16LenLimited;
+	use crate::util::atomic_counter::AtomicCounter;
+	use bitcoin::hash_types::WPubkeyHash;
+	use bitcoin::hashes::Hash;
+	use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+	use bitcoin::{PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Witness};
+	use crate::util::chacha20::ChaCha20;
+
+	// Fixtures
+
+	/// Returns pseudo-random data
+	/// TODO: Maybe this could be moved to test_utils?
+	struct TestEntropySource {
+		/// Tracks the number of times we've produced randomness to ensure we don't return the same bytes twice.
+		rand_bytes_index: AtomicCounter,
+	}
+
+	impl TestEntropySource {
+		fn new() -> Self {
+			Self { rand_bytes_index: AtomicCounter::new() }
+		}
+	}
+
+	impl EntropySource for TestEntropySource {
+		fn get_secure_random_bytes(&self) -> [u8; 32] {
+			let index = self.rand_bytes_index.get_increment();
+			let mut nonce = [0u8; 16];
+			nonce[..8].copy_from_slice(&index.to_be_bytes());
+			ChaCha20::get_single_block(&[42; 32], &nonce)
+		}
+	}
+
+	fn get_sample_channel_id() -> ChannelId {
+		ChannelId::v1_from_funding_txid(&[2; 32], 0)
+	}
+
+	fn get_sample_tx_input() -> TxIn {
+		let intxid = get_sample_input_tx().txid();
+		let previous_output = OutPoint {
+			txid: intxid,
+			index: 0,
+		}
+		.into_bitcoin_outpoint();
+		TxIn {
+			previous_output,
+			script_sig: Script::new(),
+			sequence: Sequence(0xfffffffd),
+			witness: Witness::from_vec(vec![
+				hex::decode("304402206af85b7dd67450ad12c979302fac49dfacbc6a8620f49c5da2b5721cf9565ca502207002b32fed9ce1bf095f57aeb10c36928ac60b12e723d97d2964a54640ceefa701").unwrap(),
+				hex::decode("0301ab7dc16488303549bfcdd80f6ae5ee4c20bf97ab5410bbd6b1bfa85dcd6944").unwrap()]),
+		}
+	}
+
+	fn get_sample_tx_input_2() -> TxIn {
+		let intxid = get_sample_input_tx_2().txid();
+		let previous_output = OutPoint {
+			txid: intxid,
+			index: 0,
+		}
+		.into_bitcoin_outpoint();
+		TxIn {
+			previous_output,
+			script_sig: Script::new(),
+			sequence: Sequence(0xfffffffd),
+			witness: Witness::from_vec(vec![
+				hex::decode("304402206af85b7dd67450ad12c979302fac49dfacbc6a8620f49c5da2b5721cf9565ca502207002b32fed9ce1bf095f57aeb10c36928ac60b12e723d97d2964a54640ceefa701").unwrap(),
+				hex::decode("0301ab7dc16488303549bfcdd80f6ae5ee4c20bf97ab5410bbd6b1bfa85dcd6944").unwrap()]),
+		}
+	}
+
+	fn get_sample_pubkey(num: u8) -> PublicKey {
+		let secret_key = SecretKey::from_slice(&[num; 32]).unwrap();
+		let secp_ctx = Secp256k1::new();
+		PublicKey::from_secret_key(&secp_ctx, &secret_key)
+	}
+
+	fn get_sample_input_tx_intern(pubkey: PublicKey, value: u64) -> Transaction {
+		let script_pubkey = Script::new_v0_p2wpkh(&WPubkeyHash::hash(&pubkey.serialize()));
+		let output = TxOut {
+			value,
+			script_pubkey,
+		};
+		Transaction {
+			version: 2,
+			lock_time: PackedLockTime::ZERO,
+			output: vec![output],
+			input: vec![],
+		}
+	}
+
+	fn get_sample_input_tx() -> Transaction {
+		get_sample_input_tx_intern(get_sample_pubkey(11), 550011)
+	}
+
+	fn get_sample_input_tx_2() -> Transaction {
+		get_sample_input_tx_intern(get_sample_pubkey(12), 550012)
+	}
+
+	fn get_sample_input_tx_3() -> Transaction {
+		get_sample_input_tx_intern(get_sample_pubkey(13), 550013)
+	}
+
+	fn get_sample_tx_add_input_intern(serial_id: u64, channel_id: ChannelId, prevtx: TransactionU16LenLimited) -> TxAddInput {
+		TxAddInput { channel_id, serial_id, prevtx, prevtx_out: 0, sequence: 305419896 }
+	}
+
+	fn get_sample_tx_add_input(serial_id: u64, channel_id: ChannelId) -> TxAddInput {
+		get_sample_tx_add_input_intern(serial_id, channel_id, TransactionU16LenLimited::new(get_sample_input_tx()).unwrap())
+	}
+
+	fn get_sample_tx_add_input_2(serial_id: u64, channel_id: ChannelId) -> TxAddInput {
+		get_sample_tx_add_input_intern(serial_id, channel_id, TransactionU16LenLimited::new(get_sample_input_tx_2()).unwrap())
+	}
+
+	fn get_sample_tx_add_input_3(serial_id: u64, channel_id: ChannelId) -> TxAddInput {
+		get_sample_tx_add_input_intern(serial_id, channel_id, TransactionU16LenLimited::new(get_sample_input_tx_3()).unwrap())
+	}
+
+	fn get_sample_tx_output() -> TxOut {
+		let pubkey = get_sample_pubkey(21);
+		let script_pubkey = Script::new_v0_p2wpkh(&WPubkeyHash::hash(&pubkey.serialize()));
+		TxOut {
+			value: 540021,
+			script_pubkey,
+		}
+	}
+
+	fn get_sample_tx_output_2() -> TxOut {
+		let pubkey = get_sample_pubkey(21);
+		let script_pubkey = Script::new_v0_p2wpkh(&WPubkeyHash::hash(&pubkey.serialize()));
+		TxOut {
+			value: 540022,
+			script_pubkey,
+		}
+	}
+
+	fn get_sample_tx_add_output(serial_id: u64, channel_id: ChannelId) -> TxAddOutput {
+		let tx_out = get_sample_tx_output();
+		TxAddOutput {
+			channel_id,
+			serial_id,
+			sats: tx_out.value,
+			script: tx_out.script_pubkey,
+		}
+	}
+
+	fn get_sample_tx_add_output_2(serial_id: u64, channel_id: ChannelId) -> TxAddOutput {
+		let tx_out = get_sample_tx_output_2();
+		TxAddOutput {
+			channel_id,
+			serial_id,
+			sats: tx_out.value,
+			script: tx_out.script_pubkey,
+		}
+	}
+
+	#[test]
+	fn test_negotiating_context_is_serial_id_valid() {
+
+	}
+
+	// Use shortened names here, InvHM for InvokeHandleMethod
+	#[derive(Debug)]
+	enum InvHM {
+		AddI(TxAddInput),  // AddInput
+		AddO(TxAddOutput), // AddOutput
+		Comp(ChannelId),   // Complete
+	}
+
+	// TODO return proper error
+	impl InvHM {
+		//fn do_invoke<ES: Deref>(
+		fn do_invoke(
+			&self,
+			interact_tx: &mut InteractiveTxConstructor,
+		) -> Result<(Option<InteractiveTxMessageSend>, Option<Transaction>), AbortReason>
+		// where ES::Target: EntropySource,
+		{
+			match self {
+				InvHM::AddI(txai) => {
+					let msg = interact_tx.handle_tx_add_input(txai)?;
+					Ok((Some(msg), None))
+				}
+				InvHM::AddO(txao) => {
+					let msg = interact_tx.handle_tx_add_output(txao)?;
+					Ok((Some(msg), None))
+				}
+				InvHM::Comp(channel_id) => interact_tx.handle_tx_complete(&TxComplete {
+					channel_id: *channel_id,
+				}),
+			}
+		}
+	}
+
+	// Use shortened names here, ExSt for ExpectedState
+	#[derive(Debug)]
+	enum ExSt {
+		LocalCh,	// LocalChange
+		RemoteCh,   // RemoteChange
+		LocalComp,  // LocalComplete
+		RemoteComp, // RemoteComplete
+		NegComp,	// NegotiationComplete
+		NegAb,	  // NegotiationAborted
+	}
+
+	impl ExSt {
+		fn match_state(&self, state: &StateMachine) {
+			match self {
+				ExSt::LocalCh => {
+					assert!(matches!(state, StateMachine::LocalChange(_)))
+				}
+				ExSt::RemoteCh => {
+					assert!(matches!(state, StateMachine::RemoteChange(_)))
+				}
+				ExSt::LocalComp => {
+					assert!(matches!(state, StateMachine::LocalTxComplete(_)))
+				}
+				ExSt::RemoteComp => {
+					assert!(matches!(state, StateMachine::RemoteTxComplete(_)))
+				}
+				ExSt::NegComp => {
+					assert!(matches!(state, StateMachine::NegotiationComplete(_)))
+				}
+				ExSt::NegAb => {
+					assert!(matches!(state, StateMachine::NegotiationAborted(_)))
+				}
+			}
+		}
+	}
+
+	#[derive(Debug)]
+	enum ExMsg {
+		AddI, // TxAddInput
+		AddO, // TxAddOutput
+		Comp, // TxComplete
+	}
+
+	impl ExMsg {
+		fn match_msg(&self, msg: &Option<InteractiveTxMessageSend>) {
+			match self {
+				ExMsg::AddI => assert!(matches!(
+					msg.as_ref().unwrap(),
+					InteractiveTxMessageSend::TxAddInput(_)
+				)),
+				ExMsg::AddO => assert!(matches!(
+					msg.as_ref().unwrap(),
+					InteractiveTxMessageSend::TxAddOutput(_)
+				)),
+				ExMsg::Comp => assert!(matches!(
+					msg.as_ref().unwrap(),
+					InteractiveTxMessageSend::TxComplete(_)
+				)),
+			}
+		}
+	}
+
+	/// Use shortened names here, ExTx ExpectedTxParams
+	#[derive(Debug)]
+	struct ExTx {
+		input_count: u16,
+		output_count: u16,
+	}
+
+	impl ExTx {
+		fn new(input_count: u16, output_count: u16) -> Self {
+			ExTx {
+				input_count,
+				output_count,
+			}
+		}
+
+		fn match_tx(&self, tx: &Option<Transaction>) {
+			assert_eq!(tx.as_ref().unwrap().input.len(), self.input_count as usize);
+			assert_eq!(
+				tx.as_ref().unwrap().output.len(),
+				self.output_count as usize
+			);
+		}
+	}
+
+	/// Use shortened names here, ExInvRes ExpectedInvokeResult
+	#[derive(Debug)]
+	struct ExInvRes {
+		is_error: bool,
+		state: ExSt,
+		message: Option<ExMsg>,
+		tx: Option<ExTx>,
+	}
+
+	impl ExInvRes {
+		// ctor with success result
+		fn ok(state: ExSt, message: Option<ExMsg>, tx: Option<ExTx>) -> Self {
+			Self {
+				is_error: false,
+				state,
+				message,
+				tx,
+			}
+		}
+
+		// ctor with error result
+		fn error() -> Self {
+			Self {
+				is_error: true,
+				state: ExSt::NegAb,
+				message: None,
+				tx: None,
+			}
+		}
+
+		fn match_state(&self, state: &StateMachine) {
+			self.state.match_state(state);
+		}
+
+		fn match_msg(&self, msg: &Option<InteractiveTxMessageSend>) {
+			if let Some(m) = &self.message {
+				m.match_msg(msg);
+			} else {
+				assert!(msg.is_none());
+			}
+		}
+
+		fn match_tx(&self, tx: &Option<Transaction>) {
+			if let Some(txp) = &self.tx {
+				txp.match_tx(tx);
+			} else {
+				assert!(tx.is_none());
+			}
+		}
+	}
+
+	/// InvokeStep, shortened name Invoke
+	#[derive(Debug)]
+	struct Invoke {
+		invoke: InvHM,
+		expected_state: ExInvRes,
+	}
+
+	// Test helper: create an InteractiveTxConstructor, and perform a number of steps, and check results after each.
+	fn run_interactive_tx(
+		channel_id: ChannelId,
+		is_initiator: bool,
+		local_inputs: Vec<(TxIn, Transaction)>,
+		local_outputs: Vec<TxOut>,
+		expected_initial_state: ExInvRes,
+		invocations: Vec<Invoke>,
+	) {
+		let entropy_source = TestEntropySource::new();
+		let (mut interact, msg) = InteractiveTxConstructor::new(
+			&&entropy_source,
+			channel_id,
+			FEERATE_FLOOR_SATS_PER_KW,
+			is_initiator,
+			PackedLockTime::ZERO,
+			local_inputs,
+			local_outputs,
+		);
+
+		expected_initial_state.match_state(&interact.get_state_machine());
+		expected_initial_state.match_msg(&msg);
+
+		// Process invocations
+		for i in invocations {
+			println!("Invoking {:?} ...", i);
+			let invoke_res = i.invoke.do_invoke(&mut interact);
+			// check post state
+			i.expected_state.match_state(&interact.get_state_machine());
+			if let Err(_) = invoke_res {
+				if i.expected_state.is_error {
+					// OK
+				} else {
+					panic!("Error invoking, {:?}", i.invoke);
+				}
+			} else {
+				if i.expected_state.is_error {
+					panic!("Invocation OK but expected error, {:?}", i.invoke);
+				} else {
+					// OK
+					i.expected_state.match_msg(&invoke_res.as_ref().unwrap().0);
+					i.expected_state.match_tx(&invoke_res.as_ref().unwrap().1);
+				}
+			}
+		}
+	}
+
+	// Test cases
+	//
+	// A note on naming of the tests cases:
+	// - 'init' is short for initiator
+	// - 'noni' is short for noninitiator
+	// The follows a sequence of one-letter codes indicating added inputs and outputs, as follows:
+	// - 'I': for local-added input
+	// - 'O': for local-added output
+	// - 'j': for remote-added input (letter j is somewhat similar to i)
+	// - 'u': for remote-added output (letter u is somewhat similar to o, also second letter in out)
+	// They are listed in the order they are added, e.g.: _IjOjjju_
+
+	#[test]
+	fn test_interact_tx_noni_construct() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_init_construct() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			true,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+			vec![],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_noni_ju_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input(123002, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output(123004, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(1, 1))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_init_IO_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![(get_sample_tx_input(), get_sample_input_tx())];
+		let outputs = vec![get_sample_tx_output()];
+		run_interactive_tx(
+			channel_id,
+			true,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+			vec![
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(
+						ExSt::NegComp,
+						Some(ExMsg::Comp),
+						Some(ExTx::new(1, 1)),
+					),
+				},
+			],
+		);
+	}
+
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_noni_IO_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![(get_sample_tx_input(), get_sample_input_tx())];
+		let outputs = vec![get_sample_tx_output()];
+		run_interactive_tx(
+			channel_id,
+			false,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				// TODO check why does this fail?
+				// InvokeStep {
+				//	 invoke: InvHM::HandleComplete(channel_id),
+				//	 expected_state: ExpectedInvokeResult {
+				//		 ExMsg::NegotiationAborted,
+				//		 Some(ExMsg::TxAddOutput),
+				//		 None,
+				//	 },
+				// },
+			],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_init_ju_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			true,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input(123001, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output(123003, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(1, 1))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_noni_empty_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				// Aborts as there is no input to pay for fee
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::error(),
+				},
+			],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_init_empty_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			true,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+			vec![
+				// TODO: Empty TX is accepted here, check if correct
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(0, 0))),
+				},
+			],
+		);
+	}
+
+	// Both parties contribute
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_init_IjOu_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![(get_sample_tx_input(), get_sample_input_tx())];
+		let outputs = vec![get_sample_tx_output()];
+		run_interactive_tx(
+			channel_id,
+			true,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_2(123001, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output_2(123003, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(2, 2))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_noni_jIuO_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![(get_sample_tx_input(), get_sample_input_tx())];
+		let outputs = vec![get_sample_tx_output()];
+		run_interactive_tx(
+			channel_id,
+			false,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_2(123002, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output_2(123004, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(
+						ExSt::NegComp,
+						Some(ExMsg::Comp),
+						Some(ExTx::new(2, 2)),
+					),
+				},
+			],
+		);
+	}
+
+	// TODO: no abort support!
+	// #[test]
+	// fn test_interact_tx_noni_j_u_abort() {
+	// 	let entropy_source = TestEntropySource{};
+	// 	let channel_id = get_sample_channel_id();
+	// 	let (mut interact, msg) = InteractiveTxConstructor::new(&entropy_source, channel_id, FEERATE_FLOOR_SATS_PER_KW, false, PackedLockTime::ZERO, vec![], vec![]);
+	// 	assert!(matches!(interact.get_state_machine(), StateMachine::LocalChange(_)));
+	// 	assert!(msg.is_none());
+
+	// 	let msg2 = interact.handle_abort().unwrap();
+	// 	...
+	// }
+
+	#[test]
+	fn test_interact_tx_noni_jjuu_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input(123002, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_2(123004, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output(123006, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output_2(123008, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(2, 2))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_noni_juju_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input(123002, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output(123006, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_2(123004, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output_2(123008, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(2, 2))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_init_IIOO_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![
+			(get_sample_tx_input(), get_sample_input_tx()),
+			(get_sample_tx_input_2(), get_sample_input_tx_2()),
+		];
+		let outputs = vec![get_sample_tx_output(), get_sample_tx_output_2()];
+		run_interactive_tx(
+			channel_id,
+			true,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+			vec![
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(
+						ExSt::NegComp,
+						Some(ExMsg::Comp),
+						Some(ExTx::new(2, 2)),
+					),
+				},
+			],
+		);
+	}
+
+	#[test]
+	fn test_interact_tx_noni_uj_complete() {
+		let channel_id = get_sample_channel_id();
+		run_interactive_tx(
+			channel_id,
+			false,
+			vec![],
+			vec![],
+			ExInvRes::ok(ExSt::LocalCh, None, None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output(123004, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input(123002, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(1, 1))),
+				},
+			],
+		);
+	}
+
+	#[test]
+	#[allow(non_snake_case)]
+	fn test_interact_tx_init_IuOjj_complete() {
+		let channel_id = get_sample_channel_id();
+		let inputs = vec![(get_sample_tx_input(), get_sample_input_tx())];
+		let outputs = vec![get_sample_tx_output()];
+		run_interactive_tx(
+			channel_id,
+			true,
+			inputs,
+			outputs,
+			ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddI), None),
+			vec![
+				Invoke {
+					invoke: InvHM::AddO(get_sample_tx_add_output_2(123001, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalCh, Some(ExMsg::AddO), None),
+				},
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_2(123003, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::AddI(get_sample_tx_add_input_3(123005, channel_id)),
+					expected_state: ExInvRes::ok(ExSt::LocalComp, Some(ExMsg::Comp), None),
+				},
+				Invoke {
+					invoke: InvHM::Comp(channel_id),
+					expected_state: ExInvRes::ok(ExSt::NegComp, None, Some(ExTx::new(3, 2))),
+				},
+			],
+		);
+	}
+}
+
+// #[cfg(test)]
+// mod tests {
+// 	use core::str::FromStr;
+// 	use crate::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+// use crate::ln::interactivetxs::ChannelMode::{Negotiating, NegotiationAborted};
+// 	use crate::ln::interactivetxs::{AbortReason, ChannelMode, InteractiveTxConstructor, InteractiveTxStateMachine};
+// 	use crate::ln::msgs::TransactionU16LenLimited;
+// 	use bitcoin::consensus::encode;
+// 	use bitcoin::{Address, PackedLockTime, Script, Sequence, Transaction, Txid, TxIn, TxOut, Witness};
+// 	use bitcoin::hashes::hex::FromHex;
+// 	use crate::chain::transaction::OutPoint;
+// 	use crate::ln::interactivetxs::AbortReason::IncorrectSerialIdParity;
+// 	use crate::ln::msgs::TxAddInput;
+//
+// 	#[test]
+// 	fn test_invalid_counterparty_serial_id_should_abort_negotiation() {
+// 		let tx: Transaction = encode::deserialize(&hex::decode("020000000001010e0ade\
+// 			f48412e4361325ac1c6e36411299ab09d4f083b9d8ddb55fbc06e1b0c00000000000feffffff0220a107000\
+// 			0000000220020f81d95e040bd0a493e38bae27bff52fe2bb58b93b293eb579c01c31b05c5af1dc072cfee54\
+// 			a3000016001434b1d6211af5551905dc2642d05f5b04d25a8fe80247304402207f570e3f0de50546aad25a8\
+// 			72e3df059d277e776dda4269fa0d2cc8c2ee6ec9a022054e7fae5ca94d47534c86705857c24ceea3ad51c69\
+// 			dd6051c5850304880fc43a012103cb11a1bacc223d98d91f1946c6752e358a5eb1a1c983b3e6fb15378f453\
+// 			b76bd00000000").unwrap()[..]).unwrap();
+// 		let mut constructor = InteractiveTxConstructor::new([0; 32], FEERATE_FLOOR_SATS_PER_KW, true, true, tx, false);
+// 		constructor.receive_tx_add_input(2, &get_sample_tx_add_input(), false);
+// 		assert!(matches!(constructor.mode, ChannelMode::NegotiationAborted { .. }))
+// 	}
+//
+// 	impl DummyChannel {
+// 		fn new() -> Self {
+// 			let tx: Transaction = encode::deserialize(&hex::decode("020000000001010e0ade\
+// 			f48412e4361325ac1c6e36411299ab09d4f083b9d8ddb55fbc06e1b0c00000000000feffffff0220a107000\
+// 			0000000220020f81d95e040bd0a493e38bae27bff52fe2bb58b93b293eb579c01c31b05c5af1dc072cfee54\
+// 			a3000016001434b1d6211af5551905dc2642d05f5b04d25a8fe80247304402207f570e3f0de50546aad25a8\
+// 			72e3df059d277e776dda4269fa0d2cc8c2ee6ec9a022054e7fae5ca94d47534c86705857c24ceea3ad51c69\
+// 			dd6051c5850304880fc43a012103cb11a1bacc223d98d91f1946c6752e358a5eb1a1c983b3e6fb15378f453\
+// 			b76bd00000000").unwrap()[..]).unwrap();
+// 			Self {
+// 				tx_constructor: InteractiveTxConstructor::new([0; 32], FEERATE_FLOOR_SATS_PER_KW, true, true, tx, false)
+// 			}
+// 		}
+//
+// 		fn handle_add_tx_input(&mut self) {
+// 			self.tx_constructor.receive_tx_add_input(1234, &get_sample_tx_add_input(), true)
+// 		}
+// 	}
+//
+// 	// Fixtures
+// 	fn get_sample_tx_add_input() -> TxAddInput {
+// 		let prevtx = TransactionU16LenLimited::new(
+// 			Transaction {
+// 				version: 2,
+// 				lock_time: PackedLockTime(0),
+// 				input: vec![TxIn {
+// 					previous_output: OutPoint { txid: Txid::from_hex("305bab643ee297b8b6b76b320792c8223d55082122cb606bf89382146ced9c77").unwrap(), index: 2 }.into_bitcoin_outpoint(),
+// 					script_sig: Script::new(),
+// 					sequence: Sequence(0xfffffffd),
+// 					witness: Witness::from_vec(vec![
+// 						hex::decode("304402206af85b7dd67450ad12c979302fac49dfacbc6a8620f49c5da2b5721cf9565ca502207002b32fed9ce1bf095f57aeb10c36928ac60b12e723d97d2964a54640ceefa701").unwrap(),
+// 						hex::decode("0301ab7dc16488303549bfcdd80f6ae5ee4c20bf97ab5410bbd6b1bfa85dcd6944").unwrap()]),
+// 				}],
+// 				output: vec![
+// 					TxOut {
+// 						value: 12704566,
+// 						script_pubkey: Address::from_str("bc1qzlffunw52jav8vwdu5x3jfk6sr8u22rmq3xzw2").unwrap().script_pubkey(),
+// 					},
+// 					TxOut {
+// 						value: 245148,
+// 						script_pubkey: Address::from_str("bc1qxmk834g5marzm227dgqvynd23y2nvt2ztwcw2z").unwrap().script_pubkey(),
+// 					},
+// 				],
+// 			}
+// 		).unwrap();
+//
+// 		return TxAddInput {
+// 			channel_id: [2; 32],
+// 			serial_id: 4886718345,
+// 			prevtx,
+// 			prevtx_out: 305419896,
+// 			sequence: 305419896,
+// 		};
+// 	}
+// }

--- a/lightning/src/ln/interactivetxs_tests.rs
+++ b/lightning/src/ln/interactivetxs_tests.rs
@@ -986,19 +986,8 @@ mod tests {
 			local_outputs,
 		);
 		let expected_serial_id = 0;
-		match msg {
-			Some(InteractiveTxMessageSend::TxAddInput(add)) => {
-				assert_eq!(add.serial_id, expected_serial_id);
-			}
-			_ => panic!("Expected TxAddInput!"),
-		}
-		// do a handle_complete, for the second message
+		assert!(matches!(msg, Some(InteractiveTxMessageSend::TxAddInput(add)) if add.serial_id == expected_serial_id));
 		let (msg, _tx) = interact.handle_tx_complete(&TxComplete { channel_id }).unwrap();
-		match msg {
-			Some(InteractiveTxMessageSend::TxAddInput(add)) => {
-				assert_eq!(add.serial_id, expected_serial_id);
-			}
-			_ => panic!("Expected TxAddInput!"),
-		}
+		assert!(matches!(msg, Some(InteractiveTxMessageSend::TxAddInput(add)) if add.serial_id == expected_serial_id));
 	}
 }

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -75,6 +75,8 @@ mod monitor_tests;
 mod shutdown_tests;
 #[allow(unused_mut)] // TODO
 pub(crate) mod interactivetxs;
+#[cfg(test)]
+mod interactivetxs_tests;
 
 pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;
 

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -73,6 +73,8 @@ mod monitor_tests;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod shutdown_tests;
+#[allow(unused_mut)] // TODO
+pub(crate) mod interactivetxs;
 
 pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;
 

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -436,6 +436,10 @@ pub struct ChannelReady {
 	pub short_channel_id_alias: Option<u64>,
 }
 
+/// A randomly chosen number that is used to identify inputs within an interactive transaction
+/// construction.
+pub type SerialId = u64;
+
 /// A tx_add_input message for adding an input during interactive transaction construction
 ///
 // TODO(dual_funding): Add spec link for `tx_add_input`.
@@ -445,7 +449,7 @@ pub struct TxAddInput {
 	pub channel_id: ChannelId,
 	/// A randomly chosen unique identifier for this input, which is even for initiators and odd for
 	/// non-initiators.
-	pub serial_id: u64,
+	pub serial_id: SerialId,
 	/// Serialized transaction that contains the output this input spends to verify that it is non
 	/// malleable.
 	pub prevtx: TransactionU16LenLimited,
@@ -464,7 +468,7 @@ pub struct TxAddOutput {
 	pub channel_id: ChannelId,
 	/// A randomly chosen unique identifier for this output, which is even for initiators and odd for
 	/// non-initiators.
-	pub serial_id: u64,
+	pub serial_id: SerialId,
 	/// The satoshi value of the output
 	pub sats: u64,
 	/// The scriptPubKey for the output
@@ -479,7 +483,7 @@ pub struct TxRemoveInput {
 	/// The channel ID
 	pub channel_id: ChannelId,
 	/// The serial ID of the input to be removed
-	pub serial_id: u64,
+	pub serial_id: SerialId,
 }
 
 /// A tx_remove_output message for removing an output during interactive transaction construction.
@@ -490,7 +494,7 @@ pub struct TxRemoveOutput {
 	/// The channel ID
 	pub channel_id: ChannelId,
 	/// The serial ID of the output to be removed
-	pub serial_id: u64,
+	pub serial_id: SerialId,
 }
 
 /// A tx_complete message signalling the conclusion of a peer's transaction contributions during

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1375,7 +1375,7 @@ impl Readable for Duration {
 ///
 /// Use [`TransactionU16LenLimited::into_transaction`] to convert into the contained `Transaction`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TransactionU16LenLimited(Transaction);
+pub struct TransactionU16LenLimited(pub Transaction);
 
 impl TransactionU16LenLimited {
 	/// Constructs a new `TransactionU16LenLimited` from a `Transaction` only if it's consensus-

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1394,6 +1394,7 @@ impl TransactionU16LenLimited {
 	}
 
 	/// Access inner transaction, as reference
+	#[cfg(test)]
 	pub(crate) fn inner(&self) -> &Transaction {
 		&self.0
 	}

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -1392,6 +1392,11 @@ impl TransactionU16LenLimited {
 	pub fn into_transaction(self) -> Transaction {
 		self.0
 	}
+
+	/// Access inner transaction, as reference
+	pub(crate) fn inner(&self) -> &Transaction {
+		&self.0
+	}
 }
 
 impl Writeable for TransactionU16LenLimited {


### PR DESCRIPTION
Changes:
- Several constructor unit tests, in separate file `lightning/src/ln/interactivetxs_tests.rs`
- Added `pub(crate)` in 2 places, 
- accessor method for state machine (test-only)

 